### PR TITLE
cast-ing for 32bit, long != int64_t environments

### DIFF
--- a/src/Bignum.h
+++ b/src/Bignum.h
@@ -554,7 +554,7 @@ public:
         mpz_t ret;
         mpz_init_set_si(ret, n >> 32);
         mpz_mul_2exp(ret, ret, 32);
-        const int64_t val = n & 0xffffffff;
+        const unsigned int val = n & 0xffffffff;
         mpz_add_ui(ret, ret, val);
         return makeInteger(ret);
     }

--- a/src/FFIProcedures.cpp
+++ b/src/FFIProcedures.cpp
@@ -1387,12 +1387,12 @@ Object scheme::internalFfiMallocEx(VM* theVM, int argc, const Object* argv)
     DeclareProcedureName("malloc");
     checkArgumentLength(1);
     argumentCheckExactInteger(0, size);
-    if (!Arithmetic::fitsU64(size)) {
+    if (!Arithmetic::fitsU64(size)) { // FIXME: malloc cannot allocate full-64bit size (evenif we were on 64bit-os)
         callAssertionViolationAfter(theVM, procedureName, "size out of range", L1(argv[0]));
         return Object::Undef;
     }
     const uint64_t u64Size = Arithmetic::toU64(size);
-    return Object::makePointer(malloc(u64Size));
+    return Object::makePointer(malloc((size_t)u64Size));
 }
 
 #define CALLBACK_RETURN_TYPE_INTPTR     0x0000

--- a/src/SocketBinaryInputOutputPort.h
+++ b/src/SocketBinaryInputOutputPort.h
@@ -76,7 +76,7 @@ private:
     uint8_t getLastU8()
     {
         MOSH_ASSERT(hasLastU8());
-        const uint8_t ret = lastU8_;
+        const uint8_t ret = (uint8_t) lastU8_;
         lastU8_ = 0xffff;
         return ret;
     }

--- a/src/scheme.cpp
+++ b/src/scheme.cpp
@@ -110,7 +110,7 @@ extern void initNonGenerativeRtd();
 void mosh_init()
 {
     // MOSH_GENSYM_PREFIX and equal? need this.
-    srandom(time(NULL));
+    srandom((unsigned int)time(NULL));
 #ifdef USE_BOEHM_GC
     GC_INIT();
     // N.B


### PR DESCRIPTION
(test for pull-request)

do you prefer static_cast<>s?
