### PR TITLE
fix linker option syntax for GCC 4.7

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -555,7 +555,7 @@ install-data-hook:
 # for FFI test
 lib/libffitest.so.1.0: src/ffitest.c
 	$(CC) -g -std=c99 -Wall -fPIC -c $< -o src/ffitest.o
-	$(CC) -g -Wl $(SHLIB_SO_LDFLAGS) -o $@ src/ffitest.o
+	$(CC) -g $(SHLIB_SO_LDFLAGS) -o $@ src/ffitest.o
 
 # for flymake
 check-syntax:


### PR DESCRIPTION
GCC 4.7 now gives an error when -Wl is given on a link-only command, causing 'make check' to fail with the following error:

```
gcc -g -std=c99 -Wall -fPIC -c src/ffitest.c -o src/ffitest.o
src/ffitest.c: In function ‘qsort’:
src/ffitest.c:238:3: warning: passing argument 1 of ‘compare’ makes pointer from integer without a cast [enabled by default]
src/ffitest.c:238:3: note: expected ‘const void *’ but argument is of type ‘int’
src/ffitest.c:238:3: warning: passing argument 2 of ‘compare’ makes pointer from integer without a cast [enabled by default]
src/ffitest.c:238:3: note: expected ‘const void *’ but argument is of type ‘int’
gcc -g -Wl -shared -o lib/libffitest.so.1.0 src/ffitest.o
gcc: error: unrecognized command line option ‘-Wl’
make: *** [lib/libffitest.so.1.0] Error 1
```

See http://gcc.gnu.org/gcc-4.7/porting_to.html -- "Use of invalid flags when linking".
