### PR TITLE
do not use first macro on recent gauche

### DIFF
--- a/boot/vm.scm
+++ b/boot/vm.scm
@@ -39,7 +39,7 @@
     (VM code-c  0 vm-outer-closure 0 vm-outer-closure vstack 0)))
 
 (define (apply-proc . args)
-  (let* ([proc (first args)]
+  (let* ([proc (car args)]
          [args (cdr args)]
          [adjusted_args (append
                          (take args (- (length args) 1))


### PR DESCRIPTION
The build of the cutting-edge mosh is broken on gauche 0.9.5 or later.

    gosh vm.scm compile-file-with-macro baselib.scm > baselib.scmc
    *** ERROR: invalid application: (#<macro first> ((procedure . #<closure #f>) (step init var) ((#:G543 #:G544 #:G545))))
    Stack Trace:
    _______________________________________
      0  (first args)
	    At line 42 of "./vm.scm"
      1  (apply (procedure-body a) (stack->pair-args stack sp args-num))
	    At line 461 of "./vm.scm"
      2  (vm/apply (cdr it) args)
	    At line 1505 of "./compiler-vm.scm"
      3  (pass1/expand (vm/apply (cdr it) args))
	    [unknown location]
      4  (f (car l) (null? (cdr l)))
	    At line 139 of "./compiler-vm.scm"
      5  ($map1-with-tail (lambda (b t?) (pass1/sexp->iform (pass1/expand b
	    At line 1265 of "./compiler-vm.scm"
      6  (pass1/body->iform body (append this-lvars lvars) #t)
	    At line 1303 of "./compiler-vm.scm"
      7  (pass1/sexp->iform ss '() #f)
	    At line 5148 of "./compiler-vm.scm"
      8  (pass2/optimize (pass1/sexp->iform ss '() #f) '())
	    At line 5147 of "./compiler-vm.scm"
      9  (pass3 (and (pass2/optimize (pass1/sexp->iform ss '() #f) '())))
	    At line 5147 of "./compiler-vm.scm"
     10  (merge-insn (pass3 (and (pass2/optimize (pass1/sexp->iform ss '() 
	    At line 5146 of "./compiler-vm.scm"
     11  (list->vector (merge-insn (pass3 (and (pass2/optimize (pass1/sexp-
	    At line 5145 of "./compiler-vm.scm"
     12  (pass4/fixup-labels (list->vector (merge-insn (pass3 (and (pass2/o
	    At line 5144 of "./compiler-vm.scm"
     13  (compile-partial `(lambda ,(cdadr sexp) ,(third sexp)))
	    At line 1707 of "./compiler-vm.scm"
     14  (alist-cons (caadr sexp) (compile-partial `(lambda ,(cdadr sexp) ,
	    At line 1705 of "./compiler-vm.scm"
     15  (pass1/sexp->iform ss '() #f)
	    At line 5148 of "./compiler-vm.scm"
     16  (pass2/optimize (pass1/sexp->iform ss '() #f) '())
	    At line 5147 of "./compiler-vm.scm"
     17  (pass3 (and (pass2/optimize (pass1/sexp->iform ss '() #f) '())))
	    At line 5147 of "./compiler-vm.scm"
     18  (merge-insn (pass3 (and (pass2/optimize (pass1/sexp->iform ss '() 
	    At line 5146 of "./compiler-vm.scm"
     19  (list->vector (merge-insn (pass3 (and (pass2/optimize (pass1/sexp-
	    At line 5145 of "./compiler-vm.scm"
     20  (pass4/fixup-labels (list->vector (merge-insn (pass3 (and (pass2/o
	    At line 5144 of "./compiler-vm.scm"
     21  (compile-partial obj)
	    At line 1641 of "./vm.scm"
     22  (compile-file-with-macro (third args) #t)
	    At line 1679 of "./vm.scm"
     23  (write (compile-file-with-macro (third args) #t))
	    At line 1679 of "./vm.scm"
    Makefile:61: recipe for target 'baselib.scmc' failed

I don't know what caused it, but this can be fixed by using `car` instead of `first`, as discovered by okuoku.