### PR TITLE
remove incorrect failed assertions on failure to stat file

### DIFF
--- a/src/OSCompat.cpp
+++ b/src/OSCompat.cpp
@@ -887,7 +887,6 @@ Object File::size(const ucs4string& path)
         file.close();
         return Bignum::makeIntegerFromS64(ret);
     } else {
-        MOSH_ASSERT(false);
         return Object::Undef;
     }
 #else
@@ -895,7 +894,6 @@ Object File::size(const ucs4string& path)
     if (stat(utf32toUtf8(path), &st) == 0) {
         return Bignum::makeIntegerFromS64(st.st_size);
     } else {
-        MOSH_ASSERT(false);
         return Object::Undef;
     }
 #endif


### PR DESCRIPTION
Fix for #9 -- I believe the change is as simple as this.  Those assertions have no reason to be there as far as I can see.  This does not affect the results of the test suite.