### PR TITLE
modify signature of getAddressString to avoid infinite loop on EAGAIN

### DIFF
--- a/src/OSCompatSocket.h
+++ b/src/OSCompatSocket.h
@@ -93,8 +93,8 @@ namespace scheme {
                                           ucs4string& errorMessage);
 
     private:
-        static ucs4string getAddressString(const struct addrinfo* addr);
-        static ucs4string getAddressString(const struct sockaddr* addr, socklen_t addrlen);
+        static ucs4string getAddressString(const struct addrinfo* addr, bool& isErrorOccurred);
+        static ucs4string getAddressString(const struct sockaddr* addr, socklen_t addrlen, bool& isErrorOccurred);
         void setLastError();
         int socket_;
         int lastError_;


### PR DESCRIPTION
While running a public web server with mosh, I found a strange behaviour where `accept` from the socket library can hang forever, when `getnameinfo` repeatedly returns `EAGAIN`.  Because of this, `getAddressString` from `OSCompatSocket.cpp` will busy-loop forever.  This is arguably a bug in some aspect of the network configuration of the system, or perhaps even the kernel, but it seems that Mosh should not be hardcoding this policy decision of whether to repeat the DNS call on `EAGAIN`.

So, I removed this loop and had to add an extra output parameter `isErrorOccurred` to `getAddressString` to indicate an error occurring during `getnameinfo`.  I'm not sure this is the best way to do this, but it seemed the way that was most in line with the rest of the source file.

I'm still not sure how these changes manifest from the perspective of the Scheme-language user, because I cannot reproduce this situation immediately: it seems to depend on some nebulous aspect of operating on the public Internet.  (Although if patterns continue it will reproduce itself again after a few days on my test system).

Let me know your thoughts on this.