### PR TITLE
Add basic support for docker for deveopers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ See [INSTALL](https://github.com/higepon/mosh/blob/master/INSTALL) and [doc](htt
 On Windows, see [Build](http://mosh.monaos.org/files/doc/text/Download-txt.html).
 
 # Building the cutting-edge Mosh
+## Docker
+We have Docker support to setup Mosh devlopment enviroment. Please see docker/dev directory.
 ## Requirements
 
 - [Mosh current](http://storage.osdev.info/pub/mosh/mosh-current.tar.gz)

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,18 @@
+FROM i686/ubuntu
+
+ENV LD_LIBRARY_PATH="/usr/local/lib"
+
+RUN apt update # && apt -y upgrade
+RUN apt install -y gauche wget make libgmp-dev gcc g++ autoconf automake make
+RUN apt install -y re2c bison subversion autoconf automake git
+
+
+# Oniguruma
+RUN wget https://github.com/kkos/oniguruma/releases/download/v5.9.6/onig-5.9.6.tar.gz
+RUN tar zvxf onig-5.9.6.tar.gz && cd onig-5.9.6 && ./configure && make && make install
+
+# Mosh 0.2.7
+RUN wget https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mosh-scheme/mosh-0.2.7.tar.gz
+RUN tar zvxf mosh-0.2.7.tar.gz && cd mosh-0.2.7 && ./configure && make && make install
+
+CMD ["mosh"]

--- a/docker/dev/README.md
+++ b/docker/dev/README.md
@@ -1,0 +1,12 @@
+ ## What is this?
+ This docker is supposed to be used by Mosh developers who need to bootstrap & build Mosh (See [Building the cutting-edge Mosh](https://github.com/higepon/mosh/blob/master/README.md#building-the-cutting-edge-mosh)
+ In this image
+ - All required libraries & binaries are pre-installed.
+ - Mosh 0.2.7 is pre-installed in /usr/local/bin.
+
+## How to use
+```
+# Build the image
+$  docker-compose up -d
+$ docker-compose exec mosh-0.2.7-bootstrap bash
+```

--- a/docker/dev/docker-compose.yml
+++ b/docker/dev/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+
+services:
+  mosh-0.2.7-bootstrap:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    tty: true      
+    volumes:
+      - type: bind
+        source: "./workspace"
+        target: "/workspace"        


### PR DESCRIPTION
Add docker support to have stable mosh development environment based off Ubuntu i686 image. See https://github.com/higepon/mosh/issues/14 for details.