### PR TITLE
[FreeBSD] Adds (struct kevent*) cast inside EV_SET() macro.

### DIFF
--- a/src/bsd/kqueue/kqueue_stubs.c
+++ b/src/bsd/kqueue/kqueue_stubs.c
@@ -37,22 +37,22 @@ kevent_dispose(void* p){
 
 void
 kevent_set_readevent(void* ke,int fd){
-    EV_SET(ke,fd,EVFILT_READ,EV_ADD,0,0,NULL);
+    EV_SET((struct kevent*)ke,fd,EVFILT_READ,EV_ADD,0,0,NULL);
 }
 
 void
 kevent_set_writeevent(void* ke,int fd){
-    EV_SET(ke,fd,EVFILT_WRITE,EV_ADD,0,0,NULL);
+    EV_SET((struct kevent*)ke,fd,EVFILT_WRITE,EV_ADD,0,0,NULL);
 }
 
 void
 kevent_set_enableuserevent(void* ke,int id){
-    EV_SET(ke,id,EVFILT_USER,EV_ADD,0,0,NULL);
+    EV_SET((struct kevent*)ke,id,EVFILT_USER,EV_ADD,0,0,NULL);
 }
 
 void
 kevent_set_triggeruserevent(void* ke,int id){
-    EV_SET(ke,id,EVFILT_USER,0,NOTE_TRIGGER,0,NULL);
+    EV_SET((struct kevent*)ke,id,EVFILT_USER,0,NOTE_TRIGGER,0,NULL);
 }
 
 int


### PR DESCRIPTION
As commented in https://github.com/higepon/mosh/issues/14#issuecomment-1207152656.
We applied okuoku's patch in https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=229540 so that mosh compiles on FreeBSD 12.