### PR TITLE
compiler: Allow Gauche 0.9.6+ for bootstrap

### DIFF
--- a/boot/compiler.scm
+++ b/boot/compiler.scm
@@ -44,7 +44,7 @@
   (define memq2 memq)
   (define df (lambda a '#f))
   (define print-stack (lambda a '#f))
-  (define (source-info p) (let1 src (debug-source-info p) (if (pair? src) (cons (sys-basename (car src)) (cdr src)) src)))
+  (define (source-info p) (let1 src (pair-attribute-get p 'source-info #f) (if (pair? src) (cons (sys-basename (car src)) (cdr src)) src)))
   (define (make-list-with-src-slot lst) (apply extended-list lst))
   (define (set-source-info! a b)
     (cond


### PR DESCRIPTION
Gauche no longer fetch `source-info` extended attribute in
`debug-source-info` procedure.

https://github.com/shirok/Gauche/commit/48f29e1ec25ca99ba715692afa42220b410c5f42

Confirmed on: Gauche 0.9.6 and 0.9.12