### PR TITLE
Fix build and runtime error on Ubuntu 22.04.

### DIFF
--- a/src/EqHashTable.h
+++ b/src/EqHashTable.h
@@ -35,21 +35,6 @@
 #include "HashTable.h"
 #include <unordered_map>
 
-// #if 0 // HAVE_EXT_HASHES
-// #include <ext/hash_map>
-// struct hash_func
-// {
-//     size_t operator()(scheme::Object const & s) const
-//     {
-//         return static_cast<intptr_t>(s.val);
-//     }
-// };
-// typedef __gnu_cxx::hash_map<scheme::Object,
-//                             scheme::Object,
-//                             hash_func,
-//                             std::equal_to<scheme::Object>,
-//                             gc_allocator<std::pair<const scheme::Object, scheme::Object> > > ObjectMap;
-// #else
 struct hash_func
 {
     size_t operator()(scheme::Object const & s) const

--- a/src/EqHashTable.h
+++ b/src/EqHashTable.h
@@ -33,48 +33,36 @@
 #define SCHEME_EQ_HASH_TABLE_
 
 #include "HashTable.h"
-
-#if HAVE_EXT_HASHES
-#include <ext/hash_map>
-struct hash_func
-{
-    size_t operator()(scheme::Object const & s) const
-    {
-        return static_cast<intptr_t>(s.val);
-    }
-};
-typedef __gnu_cxx::hash_map<scheme::Object,
-                            scheme::Object,
-                            hash_func,
-                            std::equal_to<scheme::Object>,
-                            gc_allocator<std::pair<const scheme::Object, scheme::Object> > > ObjectMap;
-
-#elif HAVE_TR1_HASHES
-#ifdef _WIN32
 #include <unordered_map>
-#include "gc_allocator.h"
-#else
-#include <tr1/unordered_map>
-#endif
+
+// #if 0 // HAVE_EXT_HASHES
+// #include <ext/hash_map>
+// struct hash_func
+// {
+//     size_t operator()(scheme::Object const & s) const
+//     {
+//         return static_cast<intptr_t>(s.val);
+//     }
+// };
+// typedef __gnu_cxx::hash_map<scheme::Object,
+//                             scheme::Object,
+//                             hash_func,
+//                             std::equal_to<scheme::Object>,
+//                             gc_allocator<std::pair<const scheme::Object, scheme::Object> > > ObjectMap;
+// #else
 struct hash_func
 {
     size_t operator()(scheme::Object const & s) const
     {
-        return std::tr1::hash<intptr_t>()(s.val);
+        return std::hash<intptr_t>()(s.val);
     }
 };
 
-typedef std::tr1::unordered_map<scheme::Object,
+typedef std::unordered_map<scheme::Object,
                                 scheme::Object,
                                 hash_func, std::equal_to<scheme::Object>,
                                 gc_allocator<std::pair<const scheme::Object, scheme::Object> > > ObjectMap;
-#else // std::map
-typedef std::map<scheme::Object,
-                 scheme::Object,
-                 std::less<scheme::Object>,
-                 gc_allocator<std::pair<const scheme::Object, scheme::Object> > > ObjectMap;
-#endif
-
+//#endif
 
 namespace scheme {
 

--- a/src/GenericMap.h
+++ b/src/GenericMap.h
@@ -36,16 +36,10 @@
 #include "config.h"
 #endif
 
-#if HAVE_EXT_HASHES
+#if defined(__APPLE__) && HAVE_EXT_HASHES
 #include <ext/hash_map>
 #else
-#ifdef _WIN32
 #include <unordered_map>
-#elif defined MONA
-#include <map>
-#else
-#include <tr1/unordered_map>
-#endif
 #endif
 
 extern scheme::Object genericHashFunction;
@@ -70,33 +64,21 @@ struct generic_equal_to
     }
 };
 
-#ifdef MONA
-
-struct LtObject
-{
-  bool operator()(const scheme::Object s1, const scheme::Object s2) const
-  {
-      return callHashFunction(genericHashFunction, s1) < callHashFunction(genericHashFunction, s2);
-  }
-};
-
-typedef std::map<scheme::Object,
-                 scheme::Object,
-                 LtObject,
-                 gc_allocator<std::pair<scheme::Object, scheme::Object> > > GenericMap;
-#elif defined(HAVE_EXT_HASHES)
+// 2022/8/28
+// std::unordred_map + gc_allocator + custom equal doesn't compile on macOS Monterey.
+#if defined(__APPLE__) && HAVE_EXT_HASHES
 typedef __gnu_cxx::hash_map<scheme::Object,
                             scheme::Object,
                             generic_hash_func,
                             generic_equal_to,
                             gc_allocator<std::pair<scheme::Object, scheme::Object> > > GenericMap;
 #else
-//#error todo_use tr1_instread
-typedef std::tr1::unordered_map<scheme::Object,
+typedef std::unordered_map<scheme::Object,
                                 scheme::Object,
                                 generic_hash_func,
                                 generic_equal_to,
                                 gc_allocator<std::pair<scheme::Object, scheme::Object> > > GenericMap;
+
 #endif
 
 #endif // SCHEME_GENERIC_MAP_

--- a/src/VM-Run.cpp
+++ b/src/VM-Run.cpp
@@ -58,7 +58,7 @@ Object VM::runLoop(Object* code, jmp_buf returnPoint, bool returnTable /* = fals
     pc_ = code;
     for (;;) {
         const Object insn = *pc_++;
-        SWITCH((int)insn.val) {
+        SWITCH((intptr_t)insn.val) {
         CASE(HALT)
         {
             return ac_;


### PR DESCRIPTION
- Fixed SWITCH in VM loop where label address was wrongly casted.
- Use std::ordered_map as default fall back to ext/hash_map in macOS.

See https://github.com/higepon/mosh/issues/26 for details.