### PR TITLE
autoconf: Use `pkg-config` to detect GMP and Oniguruma

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ GC_CFLAGS = \
 		-DHANDLE_FORK \
 		-DGC_NOT_DLL 
 
-GLOBAL_CFLAGS =  $(ONIG_CFLAGS) \
+GLOBAL_CFLAGS =  $(ONIG_CFLAGS) $(GMP_CFLAGS) \
 		 -g \
 		 -Wall \
 		 -I src -I $(includedir) \
@@ -29,7 +29,7 @@ GLOBAL_CFLAGS =  $(ONIG_CFLAGS) \
 
 GLOBAL_CXXFLAGS = -Wno-deprecated -std=c++11
 
-LIBS += $(ONIG_LIBS)
+LIBS += $(ONIG_LIBS) $(GMP_LIBS)
 
 include automake/dist-git-revision.mk
 

--- a/configure.ac
+++ b/configure.ac
@@ -60,9 +60,9 @@ AC_ARG_WITH([r6rs-doc],
 LOCAL_CONFIGURE_ARGS="--host=$host --build=$build"
 
 ### GMP or MPIR(gmp API)
-
-AC_CHECK_LIB(gmp, __gmpz_init, ,
-  [AC_MSG_ERROR([GNU MP not found, see http://gmplib.org/.])])
+PKG_CHECK_MODULES([GMP], [gmp],,
+                  [AC_CHECK_LIB([gmp], [__gmpz_init], ,
+                                [AC_MSG_ERROR([GNU MP not found, see http://gmplib.org/.])])])
 
 ### OpenSSL (optional)
 have_openssl=no
@@ -114,6 +114,11 @@ dnl # option1: try to link with current configuration
 dnl if test $have_onig = "no" ; then
 dnl     AC_CHECK_LIB([onig],[regexec],[LIBS="$LIBS -lonig" have_onig="yes"])
 dnl fi
+
+# Option2: use pkg-config
+if test $have_onig = no; then
+    PKG_CHECK_MODULES([ONIG], [oniguruma], have_onig=yes, have_onig=no)
+fi
 
 if test $have_onig = "no" ; then
     AC_MSG_ERROR([oniguruma not found, mosh requires oniguruma 5.x])


### PR DESCRIPTION
Use `pkg-config` to detect GMP and Oniguruma. Packaging systems for most OSes provide pkg-config definitions. By using `pkg-config`, we can reduce required `./configure` options to `PATH` only.

To replace these libraries explicitly, setenv `GMP_CFLAGS` `GMP_LIBS` `ONIG_CFLAGS` `ONIG_LIBS`.