### PR TITLE
doc: Adjust documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## What is Mosh?
-Mosh is a free and fast interpreter for Scheme as specified in the R6RS.(R6RS is the latest revision of the Scheme standard)
+Mosh is a free and fast interpreter for Scheme as specified in the R6RS.
 The current release of Mosh supports all of the features R6RS.
 See detailed information on http://mosh.monaos.org.
 
@@ -14,9 +14,6 @@ Get a release of Mosh from [Download](https://github.com/higepon/mosh/releases).
 
 #### Build and Install
 ```sh
-% export LDFLAGS=-L/opt/homebrew/lib
-% export CFLAGS=-I$/opt/homebrew/include
-% export CXXFLAGS=-I/opt/homebrew/include
 % ./configure
 % make
 % make test
@@ -24,19 +21,10 @@ Get a release of Mosh from [Download](https://github.com/higepon/mosh/releases).
 ```
 
 ### Ubuntu
+
 #### Install Dependences
 ```sh
-# gmp
-% apt install libgmp-dev 
-
-# oniguruma
-% wget https://github.com/kkos/oniguruma/releases/download/v5.9.6/onig-5.9.6.tar.gz
-% tar zvxf onig-5.9.6.tar.gz
-% cd onig-5.9.6
-% ./configure
-% make
-% make test
-% sudo make install
+% apt install libgmp-dev libonig-dev
 ```
 
 ### Other Platforms

--- a/doc/README.nmosh
+++ b/doc/README.nmosh
@@ -13,7 +13,8 @@ Simply, you can use it as mosh.
 Compatibility notes
 -------------------
  - nmosh is based on Andre van Tonder's R6RS macro and runtime implementation
-   see http://www.het.brown.edu/people/andre/macros/ for more info.
+   see http://web.archive.org/web/20210306215506/http://www.het.brown.edu/people/andre/macros/
+   for more info.
  - nmosh does not support following features included in psyntax-based mosh:
    - shared structure notation(SRFI-38)
    - shared namespace between "expand" and "run" phases
@@ -97,7 +98,7 @@ nrepl will load (nmosh) library by default. (nmosh) contains :
    - ^  : (^(a b c) (+ a b c)) == (lambda (a b c) (+ a b c))
    - ^x : (^a (+ a 1)) == (lambda (a) (+ a 1))
 
-(nmosh) library should not used by top-level programs.
+(nmosh) library should not be used by top-level programs.
 
 Program loading
 ---------------
@@ -124,14 +125,15 @@ to debug loadpath problems.
 porting guide
 =============
 
-Unfortunately, your script does not work under nmosh (but works under mosh)
+In case your script does not work under nmosh but works under mosh,
 try following to fix them.
 
 "Attempt to use binding of [foo] in library () at invalid level 1."
 -------------------------------------------------------------------
 
 nmosh has more strict rule for library import levels. If you intended to use
-library function (other than from (rnrs)), specify import level in your script.
+library function (other than from (rnrs)) during macro invocation, specify 
+import level in your script.
 
 e.g.)
    change (import (some library)) to (import (for (some library) run expand)) 
@@ -162,9 +164,6 @@ e.g.)
          (load "some/library.sls")
          (load "program.sps") ; (some library) available from here
 
-Future version of nmosh will provide cache-friendly version of (gensym)
-and (include "...").
-
 Runtime features
 ================
 
@@ -192,7 +191,7 @@ Minidebug
 When unhandled exception occurs in "expand" or "run" phase, nmosh will invoke 
 (nmosh debugger) to show some debugging information.
 
-Default debugger referenced as "minidebug". Currently, minidebug does not 
+Default debugger is referenced as "minidebug". Currently, minidebug does not 
 contain any interactive debugging feature. 
 
 Minidebug will show stack trace like:


### PR DESCRIPTION
Adjust README.md (and README.nmosh):

- R6RS is not latest standard now
- Remove `LDFLAGS` etc on macOS build instruction
- Remove Oniguruma installation and replace it with `libonig-dev` on Ubuntu
