### PR TITLE
Cygwin build fix

### DIFF
--- a/doc/README.Cygwin
+++ b/doc/README.Cygwin
@@ -1,4 +1,4 @@
-mosh on Cygwin 1.7
+mosh on Cygwin 3.x
 ==================
 
 1. Install
@@ -8,15 +8,12 @@ mosh on Cygwin 1.7
   libonig-devel
   libgmp-devel
   make
-  gcc4
-- ./configure
+- ./configure --disable-profiler
 - make
 - make install
 
 2. Limitations
 --------------
 
-- Cygwin's default compiler (gcc3) is known to miscompile Mosh.
-  Please install gcc4 via setup.exe.
-- Mosh repeatedly prints GC warnings. 
-- Mosh FFI cannot use for Cygwin libc. Use MSVCRT.DLL instead.
+- Mosh repeatedly prints GC warnings 
+- Mosh FFI is not supported on Cygwin

--- a/src/Equivalent.cpp
+++ b/src/Equivalent.cpp
@@ -29,6 +29,10 @@
  *  $Id: Equivalent.cpp 183 2008-07-04 06:19:28Z higepon $
  */
 
+#if !defined(_WIN32) && !defined(MONA)
+#define _XOPEN_SOURCE 700 // for random (SUSv4)
+#endif
+
 #include "Object.h"
 #include "Object-inl.h"
 #include "Pair.h"

--- a/src/ExecutableMemory.h
+++ b/src/ExecutableMemory.h
@@ -34,12 +34,13 @@
 
 #include "scheme.h"
 
-#ifndef _WIN32
-#include <sys/mman.h>
-#else
+#ifdef _WIN32
 #include <windows.h>
+#elif defined(__CYGWIN__)
+#include <windows.h>
+#else
+#include <sys/mman.h>
 #endif
-
 
 namespace scheme {
 
@@ -87,7 +88,7 @@ public:
         size_t roundAddr = iaddr & ~(pageSize - static_cast<size_t>(1));
         roundAddr_ = (uint8_t*)roundAddr;
         return roundAddr_;
-#elif defined(__GNUC__) && !defined(MOSH_MINGW32)
+#elif defined(__GNUC__) && !defined(MOSH_MINGW32) && !defined(__CYGWIN__)
         // obsolete?
         addr_ = (uint8_t*)valloc(size_);
 
@@ -97,7 +98,7 @@ public:
         int mode = PROT_READ | PROT_WRITE | PROT_EXEC;
         roundAddr_ = (uint8_t*)roundAddr;
         return mprotect(reinterpret_cast<void*>(roundAddr), size_ + (iaddr - roundAddr), mode) == 0;
-#elif defined(_WIN32)
+#elif defined(_WIN32) || defined(__CYGWIN__)
 		// addr_ = new uint8_t[size_];
         // DWORD oldProtect;
         // roundAddr_ = addr_;

--- a/src/OSCompat.cpp
+++ b/src/OSCompat.cpp
@@ -31,7 +31,9 @@
 
 
 #ifndef MONA
-#ifndef _WIN32
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE 1
+#elif !defined(_WIN32)
 #define _POSIX_C_SOURCE 200809L
 #endif
 #include <sys/types.h>

--- a/src/OSCompat.cpp
+++ b/src/OSCompat.cpp
@@ -31,6 +31,9 @@
 
 
 #ifndef MONA
+#ifndef _WIN32
+#define _POSIX_C_SOURCE 200809L
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>

--- a/src/OSCompatSocket.cpp
+++ b/src/OSCompatSocket.cpp
@@ -29,6 +29,10 @@
  *  $Id: OSCompatSocket.cpp 183 2008-07-04 06:19:28Z higepon $
  */
 
+#if !defined(_WIN32) && !defined(MONA)
+#define _POSIX_C_SOURCE 200809L // for addrinfo (POSIX 2001)
+#endif
+
 #include "scheme.h"
 #include "Object.h"
 #include "Object-inl.h"

--- a/src/OSCompatSocket.cpp
+++ b/src/OSCompatSocket.cpp
@@ -29,7 +29,9 @@
  *  $Id: OSCompatSocket.cpp 183 2008-07-04 06:19:28Z higepon $
  */
 
-#if !defined(_WIN32) && !defined(MONA)
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE 1
+#elif !defined(_WIN32) && !defined(MONA)
 #define _POSIX_C_SOURCE 200809L // for addrinfo (POSIX 2001)
 #endif
 

--- a/src/UtilityProcedures.cpp
+++ b/src/UtilityProcedures.cpp
@@ -31,6 +31,8 @@
 
 #ifdef MONA
 #include <monapi.h>
+#elif defined(__APPLE__)
+#define _DARWIN_C_SOURCE 1 // for struct timezone
 #elif !defined(_WIN32)
 #define _POSIX_C_SOURCE 200809L // for popen, confstr
 #endif

--- a/src/UtilityProcedures.cpp
+++ b/src/UtilityProcedures.cpp
@@ -31,6 +31,8 @@
 
 #ifdef MONA
 #include <monapi.h>
+#elif !defined(_WIN32)
+#define _POSIX_C_SOURCE 200809L // for popen, confstr
 #endif
 
 #ifdef _WIN32

--- a/src/UtilityProcedures.cpp
+++ b/src/UtilityProcedures.cpp
@@ -933,7 +933,7 @@ Object scheme::internalGetClosureNameEx(VM* theVM, int argc, const Object* argv)
     checkArgumentLength(1);
     return theVM->getClosureName(argv[0]);
 #else
-    return ucs4string(("<unknown>"));
+    return Object("<unknown>");
 #endif
 }
 

--- a/src/ffi_stub_x86_64.S
+++ b/src/ffi_stub_x86_64.S
@@ -130,6 +130,6 @@ no_sse:
     popq        %rbp
     ret
 
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(__CYGWIN__)
 .section .note.GNU-stack,"",%progbits
 #endif

--- a/src/scheme.cpp
+++ b/src/scheme.cpp
@@ -32,8 +32,12 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h> // for socklen_t
+#elif !defined(MONA)
+#define _XOPEN_SOURCE 700 // for srandom(SUSv4)
 #endif
+
 #include <stdio.h>
+#include <stdlib.h>
 #include "scheme.h"
 #include "Object.h"
 #include "Object-inl.h"

--- a/src/scheme.h
+++ b/src/scheme.h
@@ -145,9 +145,9 @@ enum {
 typedef int32_t ucs4char; // use -1 for EOF
 typedef int fixedint;
 
-#if defined(_MSC_VER) || defined(MONA)
+#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(MONA)
 const ucs4char* UC(const char *str);
-#elif defined(__CYGWIN__) || defined (_WIN32)
+#elif defined (_WIN32)
 #define UC_(x) L ## x
 #define UC(x) reinterpret_cast<const ucs4char*>(UC_(x)L"\0")
 #else

--- a/src/ucs4string.cpp
+++ b/src/ucs4string.cpp
@@ -32,7 +32,7 @@
 #include "scheme.h"
 #include "ucs4string.h"
 
-#if defined(_MSC_VER) || defined(MONA)
+#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(MONA)
 #include <map>
 #include <list>
 #include <vector>


### PR DESCRIPTION
Fix Cygwin 3.x build by:

- Revert `ucs4char` optimization for now
- ExecutableMemory: Use Win32 API instead

Currently profiler is not ported to Cygwin environment so we still need `--disable-profiler` option against `./configure`. Confirmed with Win10 + Cygwin 3.4. (Cygwin 3.4 and later is amd64 only.)

This PR also address:

- Explicitly make POSIX APIs visible with `_POSIX_C_SOURCE` and `_XOPEN_SOURCE` where required. (Cygwin mandates this with non-GNU standards like `-std=c++11` because these are `__STRICT_ANSI__`.)
- Fix `--disable-profiler` build by fixing string object construction