### PR TITLE
Prefer non-pkg-config way to detect libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Get a release of Mosh from [Download](https://github.com/higepon/mosh/releases).
 ### macOS
 #### Install Dependences
 ```sh
-% brew install gmp oniguruma
+% brew install pkg-config gmp oniguruma
 ```
 
 #### Build and Install
@@ -24,7 +24,7 @@ Get a release of Mosh from [Download](https://github.com/higepon/mosh/releases).
 
 #### Install Dependences
 ```sh
-% apt install libgmp-dev libonig-dev
+% apt install pkg-config libgmp-dev libonig-dev
 ```
 
 #### Build and Install

--- a/configure.ac
+++ b/configure.ac
@@ -60,9 +60,17 @@ AC_ARG_WITH([r6rs-doc],
 LOCAL_CONFIGURE_ARGS="--host=$host --build=$build"
 
 ### GMP or MPIR(gmp API)
-PKG_CHECK_MODULES([GMP], [gmp],,
-                  [AC_CHECK_LIB([gmp], [__gmpz_init], ,
-                                [AC_MSG_ERROR([GNU MP not found, see http://gmplib.org/.])])])
+have_gmp=no
+AC_CHECK_LIB([gmp], [__gmpz_init], have_gmp=yes GMP_LIBS=-lgmp,)
+
+# Fallback to pkg-config
+AS_IF([test $have_gmp = no], [
+       PKG_CHECK_MODULES([GMP], [gmp], have_gmp=yes,)
+])
+
+if test $have_gmp = no; then
+    AC_MSG_ERROR("GNU MP not found. see http://gmplib.org/.")
+fi
 
 ### OpenSSL (optional)
 have_openssl=no
@@ -115,10 +123,10 @@ dnl if test $have_onig = "no" ; then
 dnl     AC_CHECK_LIB([onig],[regexec],[LIBS="$LIBS -lonig" have_onig="yes"])
 dnl fi
 
-# Option2: use pkg-config
-if test $have_onig = no; then
-    PKG_CHECK_MODULES([ONIG], [oniguruma], have_onig=yes, have_onig=no)
-fi
+# option2: Use pkg-config
+AS_IF([test $have_onig = no], [
+       PKG_CHECK_MODULES([ONIG], [oniguruma], have_onig=yes,)
+])
 
 if test $have_onig = "no" ; then
     AC_MSG_ERROR([oniguruma not found, mosh requires oniguruma 5.x])


### PR DESCRIPTION
Previously, `configure.ac` always prefer `pkg-config` result and it will fail to `./configure` when the system did not have `pkg-config`, as found in #48 .

This patch reverse the behaviour for compatibility and make `pkg-config` optional. I think future version should always prefer `pkg-config` but it'd be better keep previous behaviour so we have migration period.

- `README.md` now instructs `pkg-config` as requirement. To detect GMP and Oniguruma from apt package, we also need `pkg-config`. Sane desktop development environment should have `pkg-config` but it is not absolutely true; current `pkg-config` population is 40% https://qa.debian.org/popcon.php?package=pkg-config (for comparison, git is 51% https://qa.debian.org/popcon.php?package=git ).
- Rewrite GMP checking. `AC_CHECK_LIB` now have `have_gmp=yes` so we lost its default behaviour(append `-lgmp` to `LIBS` ) as well. Fill `GMP_LIBS` instead here, which is referenced in `Makefile.am`.
- Fix Oniguruma handling. `PKG_CHECK_MODULES` cannot be plain conditional; needs to be surrounded inside `AS_IF` as explained in https://autotools.info/pkgconfig/pkg_check_modules.html .