### PR TITLE
Support (scheme r5rs)

### DIFF
--- a/boot/runtimes/psyntax-mosh/psyntax-buildscript-mosh.ss
+++ b/boot/runtimes/psyntax-mosh/psyntax-buildscript-mosh.ss
@@ -31,7 +31,7 @@
   (psyntax library-manager)
   (psyntax expander)
   (except (system) make-parameter parameterize mosh-cache-dir)
-  (except (mosh) library-path mosh-cache-dir)
+  (except (mosh) library-path mosh-cache-dir load)
   )
 
 ;; To prevent symbol collision between psyntax and other process,
@@ -1199,7 +1199,7 @@
     ;;;
     (char-ready?                                )
     (interaction-environment                    )
-    (load                                       )
+    (load                     mosh)
     ;;;
     (void                     $boot)
     (gensym                   $boot)

--- a/boot/runtimes/psyntax-mosh/psyntax/library-manager.ss
+++ b/boot/runtimes/psyntax-mosh/psyntax/library-manager.ss
@@ -131,7 +131,7 @@
 
   (define library-extensions
     (make-parameter
-      '(".sls" ".ss" ".scm")
+      '(".mosh.sls" ".sls" ".ss" ".scm")
       (lambda (x)
         (if (and (list? x) (for-all string? x))
             (map (lambda (x) x) x)

--- a/boot/runtimes/psyntax-mosh/psyntax/main.ss
+++ b/boot/runtimes/psyntax-mosh/psyntax/main.ss
@@ -37,7 +37,7 @@
     (rnrs records procedural)
     ;(rename (rnrs programs) (command-line get-command-line))
     (only (rnrs programs) exit)
-    (except (mosh) library-path  mosh-cache-dir);; for get-command-line
+    (except (mosh) load library-path  mosh-cache-dir);; for get-command-line
     (rnrs lists)
     (only (rnrs conditions) condition? condition make-non-continuable-violation make-who-condition make-message-condition make-irritants-condition serious-condition? who-condition? message-condition? violation? irritants-condition? condition-who condition-message condition-irritants simple-conditions)
     (only (rnrs exceptions) raise with-exception-handler guard)

--- a/lib/scheme/r5rs.sls
+++ b/lib/scheme/r5rs.sls
@@ -1,0 +1,130 @@
+(library (scheme r5rs)
+        (export 
+* +
+- ...
+/ <
+<= =
+=> >
+>=
+abs acos
+and angle
+append apply
+asin assoc
+assq assv
+atan begin
+boolean? caaaar
+caaadr caaar
+caadar caaddr
+caadr caar
+cadaar cadadr
+cadar caddar
+cadddr caddr
+cadr
+call-with-current-continuation
+call-with-input-file call-with-output-file
+call-with-values car
+case cdaaar
+cdaadr cdaar
+cdadar cdaddr
+cdadr cdar
+cddaar cddadr
+cddar cdddar
+cddddr cdddr
+cddr cdr
+ceiling char->integer
+char-alphabetic? char-ci<=?
+char-ci<? char-ci=?
+char-ci>=? char-ci>?
+char-downcase char-lower-case?
+char-numeric? char-ready?
+char-upcase char-upper-case?
+char-whitespace? char<=?
+char<? char=?
+char>=? char>?
+char? close-input-port
+close-output-port complex?
+cond cons
+cos current-input-port
+current-output-port define
+define-syntax delay
+denominator display
+do dynamic-wind
+else eof-object?
+eq? equal?
+eqv? eval
+even? exact->inexact
+exact? exp
+expt floor
+for-each force
+gcd if
+imag-part inexact->exact
+inexact? input-port?
+integer->char integer?
+interaction-environment lambda
+lcm length
+let let*
+let-syntax letrec
+letrec-syntax list
+list->string list->vector
+list-ref list-tail
+list? load
+log magnitude
+make-polar make-rectangular
+make-string make-vector
+map max
+member memq
+memv min
+modulo negative?
+newline not
+null-environment null?
+number->string number?
+numerator odd?
+open-input-file open-output-file
+or output-port?
+pair? peek-char
+positive? procedure?
+quasiquote quote
+quotient rational?
+rationalize read
+read-char real-part
+real? remainder
+reverse round
+scheme-report-environment
+set! set-car!
+set-cdr! sin
+sqrt string
+string->list string->number
+string->symbol string-append
+string-ci<=? string-ci<?
+string-ci=? string-ci>=?
+string-ci>? string-copy
+string-fill! string-length
+string-ref string-set!
+string<=? string<?
+string=? string>=?
+string>? string?
+substring symbol->string
+symbol? syntax-rules
+tan truncate
+values vector
+vector->list vector-fill!
+vector-length vector-ref
+vector-set! vector?
+with-input-from-file with-output-to-file
+write write-char
+zero?
+          )
+        (import (rnrs)
+                (rnrs mutable-pairs (6))
+                (rnrs r5rs (6))
+                (rnrs eval)
+                (only (mosh) load)
+                (rnrs mutable-strings (6)))
+                
+(define (interaction-environment)
+    (raise "interaction-environment is not supported"))
+
+(define (char-ready? p)
+    (raise "char-ready not supported"))
+
+)


### PR DESCRIPTION
By this change. Mosh doesn't complain anything when importing ```(rnrs r5rs)```

```
# ./mosh
mosh> (import (rnrs r5rs))
#<unspecified>
```

I started small here to make sure I'm doing it right.
