### PR TITLE
FreeBSD: Fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,3 +296,29 @@ jobs:
           make test &&
           make install
         shell: alpine.sh --root {0}
+
+  build-dist-fbsd:
+    name: "FreeBSD VM (Using Ubuntu bootstrap)"
+    needs: build-linux
+    runs-on: macos-12
+    steps:
+      - name: "Download artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: source-ubuntu-latest
+      - name: "Extract artifact"
+        run: |
+          tar xzv -f ${{ env.mosh_latest }}.tar.gz
+          rm ${{ env.mosh_latest }}.tar.gz
+      - name: "Build with VM"
+        uses: vmactions/freebsd-vm@7e9c9b4739d44e31230721d552f42b8e6a539d37
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg install -y gmake oniguruma pkgconf gmp
+          run: |
+            cd ${{ env.mosh_latest }}
+            ./configure
+            gmake -j4
+            gmake test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -246,7 +246,7 @@ jobs:
           path: mosh-latest/mosh-*.tar.gz
 
   build-dist-cygwin:
-    name: "Cygwin (Using Ubuntu bootstrap)"
+    name: "Cygwin"
     needs: build-linux
     runs-on: windows-latest
     steps:
@@ -272,7 +272,7 @@ jobs:
 
 
   build-dist-alpine: # So we can check on musl
-    name: "Alpine chroot (Using Ubuntu bootstrap)"
+    name: "Alpine chroot"
     needs: build-linux
     runs-on: ubuntu-latest
     steps:
@@ -298,7 +298,7 @@ jobs:
         shell: alpine.sh --root {0}
 
   build-dist-fbsd:
-    name: "FreeBSD VM (Using Ubuntu bootstrap)"
+    name: "FreeBSD VM"
     needs: build-linux
     runs-on: macos-12
     steps:

--- a/src/OSCompat.cpp
+++ b/src/OSCompat.cpp
@@ -33,6 +33,8 @@
 #ifndef MONA
 #ifdef __APPLE__
 #define _DARWIN_C_SOURCE 1
+#elif defined(__FreeBSD__)
+/* default visibility for sysctl */
 #elif !defined(_WIN32)
 #define _POSIX_C_SOURCE 200809L
 #endif

--- a/src/UtilityProcedures.cpp
+++ b/src/UtilityProcedures.cpp
@@ -33,6 +33,8 @@
 #include <monapi.h>
 #elif defined(__APPLE__)
 #define _DARWIN_C_SOURCE 1 // for struct timezone
+#elif defined(__FreeBSD__)
+#define _XOPEN_SOURCE 700 // for gettimeofday
 #elif !defined(_WIN32)
 #define _POSIX_C_SOURCE 200809L // for popen, confstr
 #endif


### PR DESCRIPTION
Fix build by adjusting feature detection macro.

- Add FreeBSD CI using macOS + VirtualBox
- Also adjust CI build names for Cygwin and Alpine as it's clear that we're build them after Ubuntu from Summary page.

![image](https://user-images.githubusercontent.com/100813/189973435-4834b3e5-05f3-4d8f-82d6-3fb26b688779.png)
