### PR TITLE
Add NetBSD and OpenBSD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,3 +322,55 @@ jobs:
             ./configure
             gmake -j4
             gmake test
+
+  build-dist-nbsd:
+    name: "NetBSD VM"
+    needs: build-linux
+    runs-on: macos-12
+    steps:
+      - name: "Download artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: source-ubuntu-latest
+      - name: "Extract artifact"
+        run: |
+          tar xzv -f ${{ env.mosh_latest }}.tar.gz
+          rm ${{ env.mosh_latest }}.tar.gz
+      - name: "Build with VM"
+        uses: vmactions/netbsd-vm@8f54bcd9711f9b85d41efd8eddcbb74b0d8aeb63
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg_add pkgin
+            pkgin -y install gmake oniguruma gmp pkgconf
+          run: |
+            cd ${{ env.mosh_latest }}
+            ./configure
+            gmake -j4
+            gmake test
+
+  build-dist-obsd:
+    name: "OpenBSD VM (Build only)"
+    needs: build-linux
+    runs-on: macos-12
+    steps:
+      - name: "Download artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: source-ubuntu-latest
+      - name: "Extract artifact"
+        run: |
+          tar xzv -f ${{ env.mosh_latest }}.tar.gz
+          rm ${{ env.mosh_latest }}.tar.gz
+      - name: "Build with VM"
+        uses: vmactions/openbsd-vm@847a57cb2a0b10808205a7ca805b914a5daa29c0
+        with:
+          usesh: true
+          copyback: false
+          prepare: |
+            pkg_add pkgconf oniguruma gmp gmake
+          run: |
+            cd ${{ env.mosh_latest }}
+            ./configure
+            gmake -j4

--- a/configure.ac
+++ b/configure.ac
@@ -257,6 +257,10 @@ netbsd*)
   AC_DEFINE(GC_NETBSD_THREADS,1,[Define to use NetBSD threads])
   has_gc_pthread=true
   ;;
+openbsd*)
+  AC_DEFINE(GC_OPENBSD_THREADS,1,[Define to use OpenBSD threads])
+  has_gc_pthread=true
+  ;;
 cygwin)
   AC_DEFINE(GC_THREADS,1,[Define to use generic thread support])
   AC_DEFINE(_REENTRANT,1,[Define to use reentrant libc])
@@ -318,6 +322,10 @@ i[[3456]]86|pentium)
          MOSH_OPTS="$MOSH_INTEL_OPTS"
          MOSH_LDADD_ARCH="-lpthread"
          ;;
+       *openbsd*)
+         MOSH_OPTS="$MOSH_INTEL_OPTS"
+         MOSH_LDADD_ARCH="-lpthread"
+         ;;
        *mingw*) #FIXME: now broken
          MOSH_OPTS="$MOSH_GENERIC_OPTS -mtune=generic -DMOSH_MINGW32 -D_UNICODE -DUNICODE -DWINVER=0x501 -D_WIN32_WINNT=0x501 -static-libgcc -static-libstdc++  -fwide-exec-charset=ucs-4le" #forcing WinXP & Gcc >= 4.5
          MOSH_LDADD_ARCH="-lshlwapi -lshell32 -lws2_32"
@@ -354,6 +362,11 @@ i[[3456]]86|pentium)
                 ;;
                 *netbsd*)
                 AC_MSG_RESULT([x86_64(NetBSD amd64)])
+                MOSH_OPTS="$MOSH_INTEL_OPTS"
+                MOSH_LDADD_ARCH="-lpthread"
+                ;;
+                *openbsd*)
+                AC_MSG_RESULT([x86_64(OpenBSD amd64)])
                 MOSH_OPTS="$MOSH_INTEL_OPTS"
                 MOSH_LDADD_ARCH="-lpthread"
                 ;;

--- a/src/Equivalent.cpp
+++ b/src/Equivalent.cpp
@@ -29,7 +29,9 @@
  *  $Id: Equivalent.cpp 183 2008-07-04 06:19:28Z higepon $
  */
 
-#if !defined(_WIN32) && !defined(MONA)
+#if defined(__NetBSD__)
+#define _NETBSD_SOURCE 1 // for C++ header work
+#elif !defined(_WIN32) && !defined(MONA)
 #define _XOPEN_SOURCE 700 // for random (SUSv4)
 #endif
 

--- a/src/OSCompat.cpp
+++ b/src/OSCompat.cpp
@@ -35,6 +35,8 @@
 #define _DARWIN_C_SOURCE 1
 #elif defined(__FreeBSD__)
 /* default visibility for sysctl */
+#elif defined(__NetBSD__)
+#define _NETBSD_SOURCE 1
 #elif !defined(_WIN32)
 #define _POSIX_C_SOURCE 200809L
 #endif

--- a/src/OSCompat.cpp
+++ b/src/OSCompat.cpp
@@ -995,6 +995,10 @@ ucs4string scheme::getMoshExecutablePath(bool& isErrorOccured)
     }
     isErrorOccured = true;
     return ucs4string(UC(""));
+#elif defined(__OpenBSD__)
+    // FIXME: TODO
+    isErrorOccured = true;
+    return ucs4string(UC(""));
 #elif defined(__sun)
     char path[4096];
     char procpath[64];

--- a/src/OSCompatSocket.cpp
+++ b/src/OSCompatSocket.cpp
@@ -31,6 +31,8 @@
 
 #ifdef __APPLE__
 #define _DARWIN_C_SOURCE 1
+#elif defined(__NetBSD__)
+#define _NETBSD_SOURCE 1
 #elif !defined(_WIN32) && !defined(MONA)
 #define _POSIX_C_SOURCE 200809L // for addrinfo (POSIX 2001)
 #endif

--- a/src/OSCompatSocket.cpp
+++ b/src/OSCompatSocket.cpp
@@ -33,6 +33,8 @@
 #define _DARWIN_C_SOURCE 1
 #elif defined(__NetBSD__)
 #define _NETBSD_SOURCE 1
+#elif defined(__OpenBSD__)
+#define _BSD_SOURCE 1
 #elif !defined(_WIN32) && !defined(MONA)
 #define _POSIX_C_SOURCE 200809L // for addrinfo (POSIX 2001)
 #endif

--- a/src/UtilityProcedures.cpp
+++ b/src/UtilityProcedures.cpp
@@ -35,6 +35,8 @@
 #define _DARWIN_C_SOURCE 1 // for struct timezone
 #elif defined(__FreeBSD__)
 #define _XOPEN_SOURCE 700 // for gettimeofday
+#elif defined(__NetBSD__)
+#define _NETBSD_SOURCE 1 // for C++ headers work
 #elif !defined(_WIN32)
 #define _POSIX_C_SOURCE 200809L // for popen, confstr
 #endif

--- a/src/posix/socket/posix_socket.c
+++ b/src/posix/socket/posix_socket.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>

--- a/src/scheme.cpp
+++ b/src/scheme.cpp
@@ -32,7 +32,11 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h> // for socklen_t
-#elif !defined(MONA)
+#elif defined(MONA)
+/* Do nothing */
+#elif defined(__NetBSD__)
+#define _NETBSD_SOURCE 1 // for C++ header work
+#else
 #define _XOPEN_SOURCE 700 // for srandom(SUSv4)
 #endif
 


### PR DESCRIPTION
Add NetBSD and OpenBSD to CI.

- On OpenBSD, `getMoshExecutablePath` is not implemented so `make test` doesn't pass. Other tests and basic functionalities are fine.
- CI uses `pkgconf` https://github.com/pkgconf/pkgconf instead of `pkg-config`. It is mostly-compatible pkg-config implementation with fewer dependency.