### PR TITLE
Activate `make check` on Linux and fix build Cygwin/BSDs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
           ./gen-git-build.sh &&
           ./configure --with-r6rs-doc=../r6rs &&
           make &&
-          make test &&
+          make check &&
           sudo make install &&
           make dist
       - name: Build the generated dist package.
@@ -100,7 +100,7 @@ jobs:
           cd $DIST_DIR &&
           ./configure --prefix=/tmp &&
           make &&
-          make test &&
+          make check &&
           make install
       - name: Run clang-tidy and treat warnings as error using bear 2.x.
         if: matrix.os == 'ubuntu-latest'
@@ -226,7 +226,7 @@ jobs:
           ./gen-git-build.sh &&
           ./configure --with-r6rs-doc=../r6rs &&
           make &&
-          make test &&
+          make check &&
           sudo make install &&
           make dist
       - name: Build the generated dist package.
@@ -238,7 +238,7 @@ jobs:
           cd $DIST_DIR &&
           ./configure --prefix=/tmp &&
           make &&
-          make test &&
+          make check &&
           make install
       - uses: actions/upload-artifact@v2
         with:
@@ -265,6 +265,7 @@ jobs:
         #run: cmake -E tar zxvf ${{ env.mosh_latest }}.tar.gz
         working-directory: build
       - name: "Build & Test"
+        # FIXME: We need to fix `test_vm` to enable check
         working-directory: build/${{ env.mosh_latest }}
         run: |
           ./configure --disable-profiler && make -j4 && make test && make install
@@ -293,7 +294,7 @@ jobs:
           cd /${{ env.mosh_latest}} &&
           ./configure &&
           make -j4 &&
-          make test &&
+          make check &&
           make install
         shell: alpine.sh --root {0}
 
@@ -322,7 +323,7 @@ jobs:
             cd ${{ env.mosh_latest }}
             ./configure
             gmake -j4
-            gmake test
+            gmake check
 
   build-dist-nbsd:
     name: "NetBSD VM"
@@ -339,6 +340,7 @@ jobs:
           rm ${{ env.mosh_latest }}.tar.gz
       - name: "Build with VM"
         uses: vmactions/netbsd-vm@8f54bcd9711f9b85d41efd8eddcbb74b0d8aeb63
+        # FIXME: We need to fix `test_ffi` to enable check
         with:
           usesh: true
           copyback: false
@@ -349,7 +351,7 @@ jobs:
             cd ${{ env.mosh_latest }}
             ./configure
             gmake -j4
-            gmake test
+            gmake test 
 
   build-dist-obsd:
     name: "OpenBSD VM (Build only)"

--- a/gtest/gtest/gtest.h
+++ b/gtest/gtest/gtest.h
@@ -51,6 +51,10 @@
 #ifndef GTEST_INCLUDE_GTEST_GTEST_H_
 #define GTEST_INCLUDE_GTEST_GTEST_H_
 
+#ifdef __CYGWIN__
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <limits>
 #include <vector>
 

--- a/gtest/gtest/gtest.h
+++ b/gtest/gtest/gtest.h
@@ -318,10 +318,17 @@
 #define GTEST_OS_SOLARIS 1
 #elif defined(_AIX)
 #define GTEST_OS_AIX 1
+#elif defined(__NetBSD__)
+#define GTEST_OS_NETBSD 1
+#elif defined(__FreeBSD__)
+#define GTEST_OS_FREEBSD 1
+#elif defined(__OpenBSD__)
+#define GTEST_OS_OPENBSD 1
 #endif  // __CYGWIN__
 
 #if GTEST_OS_CYGWIN || GTEST_OS_LINUX || GTEST_OS_MAC || GTEST_OS_SYMBIAN || \
-    GTEST_OS_SOLARIS || GTEST_OS_AIX
+    GTEST_OS_SOLARIS || GTEST_OS_AIX || GTEST_OS_NETBSD || \
+    GTEST_OS_FREEBSD || GTEST_OS_OPENBSD
 
 // On some platforms, <regex.h> needs someone to define size_t, and
 // won't compile otherwise.  We can #include it here as we already

--- a/src/FFITest.cpp
+++ b/src/FFITest.cpp
@@ -301,7 +301,7 @@ TEST_F(FFITest, refUint64_t) {
     EXPECT_EQ(0xffffffffeeeeeeeeLL, p.ref<uint64_t>(0));
 }
 
-#if defined(ARCH_IA32) || defined(ARCH_X86_64)
+#if (defined(ARCH_IA32) || defined(ARCH_X86_64)) && !(defined(__CYGWIN__) || defined(_WIN32))
 TEST_F(FFITest, ExecutableMemory) {
     ExecutableMemory mem(32);
     ASSERT_TRUE(mem.allocate());

--- a/src/getoptUTest.cpp
+++ b/src/getoptUTest.cpp
@@ -40,6 +40,10 @@
 #include "getoptU.h"
 #include "VM.h"
 
+#ifdef __CYGWIN__
+#define FIXME_EMULATED_UCS4CHAR 1 // FIXME: These tests are not compatible with sizeof(wchar_t) == 2 platforms.
+#endif
+
 using namespace scheme;
 
 #ifdef WITH_NMOSH_DEFAULTS
@@ -93,6 +97,7 @@ TEST_F(MoshTest, getopt_longU_2) {
     ASSERT_EQ(-1, getopt_longU(argc, argv, UC("htvpVcl:5rze"), long_options, &optionIndex));
 }
 
+#ifndef FIXME_EMULATED_UCS4CHAR
 TEST_F(MoshTest, getopt_longU_3) {
     struct optionU long_options[] = {
        {UC("help"), 0, 0, 'h'},
@@ -124,6 +129,7 @@ TEST_F(MoshTest, getopt_longU_4) {
     EXPECT_TRUE(path == UC("my-library"));
     ASSERT_EQ(-1, getopt_longU(argc, argv, UC("hあtvpVcl:5rze"), long_options, &optionIndex));
 }
+#endif
 
 TEST_F(MoshTest, getopt_longU_5) {
     struct optionU long_options[] = {
@@ -203,6 +209,7 @@ TEST_F(MoshTest, getopt_longU_8) {
     EXPECT_TRUE(script == argv3);
 }
 
+#ifndef FIXME_EMULATED_UCS4CHAR
 TEST_F(MoshTest, getopt_longU_9) {
     struct optionU long_options[] = {
         {UC("loadpath"), optional_argument, 0, 'L'},
@@ -244,3 +251,4 @@ TEST_F(MoshTest, getopt_longU_10) {
     ucs4string script(argv[optindU]);
     EXPECT_TRUE(script == argv3);
 }
+#endif


### PR DESCRIPTION
Fixes #87 

Activate `make check` on Linux and fix build on Cygwin/BSDs.

`make test` activated on:

- Linux
- macOS
- FreeBSD

Fixed GTest builds on:

- Cygwin (not enabled because of `test_vm` failure -- sensitive on textual output of backtrace)
- NetBSD (not enabled because of unknown failure on `test_ffi`)
- OpenBSD (not tested at all for now)

On Cygwin, some of tests are disabled because it won't work:

- getoutU: Will be worked on #93 
- FFITest: It is incompatible with Windows on AMD64