### PR TITLE
Add Win64 AMD64 to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 env:
   mosh_stable: mosh-0.2.8-rc4 # Stable tagname
   mosh_latest: mosh-0.2.8-rc4 # Built package name
+  nmosh_prereq_ver: v0.1.1 # Prebuilt libraries for NMosh package
 
 on:
   push:
@@ -377,3 +378,45 @@ jobs:
             cd ${{ env.mosh_latest }}
             ./configure
             gmake -j4
+
+  build-dist-win64:
+    name: "Win64 AMD64 (NMosh, Build only)"
+    needs: build-linux
+    runs-on: windows-2022
+    steps:
+      - name: "Prepare working directories"
+        run: |
+          mkdir prereq
+          mkdir src
+          mkdir build
+      - name: "Download prerequisites"
+        working-directory: prereq
+        run: |
+          C:\msys64\usr\bin\wget.exe https://github.com/okuoku/nmosh-build-prerequisites/releases/download/${{ env.nmosh_prereq_ver }}/nmosh-build-prerequisites-winnative.zip
+      - name: "Install prerequisites"
+        working-directory: prereq
+        run: |
+          cmake -E tar xv nmosh-build-prerequisites-winnative.zip
+      - name: "Download artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: source-ubuntu-latest
+          path: src
+      - name: "Extract artifact"
+        working-directory: src
+        run: |
+          cmake -E tar xzv ${{ env.mosh_latest }}.tar.gz
+      - name: "Import VS2022"
+        uses: ilammy/msvc-dev-cmd@v1.11.0
+        with:
+          vsversion: "2022"
+      - name: "Configure"
+        working-directory: build
+        run: |
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/prereq/nmosh-build-prerequisites-winnative/scripts/buildsystems/vcpkg.cmake ${{ github.workspace }}/src/${{ env.mosh_latest }}
+      - name: "Build"
+        working-directory: build
+        run: |
+          ninja
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ if(MOSH_PORTABLE)
         message(STATUS "Prefix-less mode was silently enabled.")
         add_definitions(-DWITH_NMOSH_PREFIXLESS)
     endif()
-endif(MOSH_PORTABLE)
+endif()
 
 if(MOSH_GC_PARALLEL_MARK)
     add_definitions(-DPARALLEL_MARK)
@@ -63,9 +63,6 @@ endif()
 if(MOSH_PREFIXLESS)
     add_definitions(-DWITH_NMOSH_PREFIXLESS)
 endif()
-
-# external libraries
-# MOSH_GMP_DIR is MSVC only
 
 # sanity check
 
@@ -91,6 +88,13 @@ endif()
 mark_as_advanced(MOSH_WITH_NMOSH 
     MOSH_VERSION MOSH_BUGREPORT MOSH_NAME MOSH_LIB_PATH MOSH_DEBUG_VERSION)
 
+if(MSVC)
+    set(builtin_atomic)
+    # FIXME: Find atomic-ops here
+else()
+    set(builtin_atomic -DGC_BUILTIN_ATOMIC=1)
+endif()
+
 add_definitions(-DHAVE_CONFIG_H
     -DMOSH_LIB_PATH=\"${MOSH_LIB_PATH}\"
     -DPACKAGE=\"${MOSH_NAME}\"
@@ -105,7 +109,7 @@ add_definitions(-DHAVE_CONFIG_H
     -DATOMIC_UNCOLLECTABLE=1
     -DNO_EXECUTE_PERMISSION=1
     -DALL_INTERIOR_POINTERS=1
-    #-DGC_BUILTIN_ATOMIC=1 # is for GCC
+    ${builtin_atomic}
     -DGC_GCJ_SUPPORT=1
     -DJAVA_FINALIZATION=1
     -DUSE_I686_PREFETCH
@@ -144,12 +148,12 @@ if(CMAKE_HOST_WIN32)
         #add_definitions(-fwide-exec-charset=ucs-4le)
         add_definitions(-DMOSH_MINGW32)
         add_definitions(-DHAVE_EXT_HASHES=1)
-    endif(MSVC)
+    endif()
 elseif(APPLE)
     if(XCODE_VERSION)
         add_definitions(-DHAVE_EXT_HASHES=1)
         add_definitions(-DUSE_XCODE) # to disable direct-threaded code in XCode 3.x
-    endif(XCODE_VERSION)
+    endif()
 
     add_definitions(-DMOSH_HOST_OS=\"darwin\")
     add_definitions(-DLINE_FEED_CODE_LF=1)
@@ -171,13 +175,12 @@ else() # so it is UNIX
 endif()
 
 if(CMAKE_HOST_WIN32)
-add_definitions(
-    -DWINVER=0x501
-    -DGC_NOT_DLL
-    -DONIG_EXTERN=extern
-    )
-set(ARCH_INCLUDE "${PROJECT_SOURCE_DIR}/src/win/include"
-    "${PROJECT_SOURCE_DIR}/src/win32")
+    add_definitions(
+        -DWINVER=0x501
+        -DGC_NOT_DLL
+        )
+    set(ARCH_INCLUDE "${PROJECT_SOURCE_DIR}/src/win/include"
+        "${PROJECT_SOURCE_DIR}/src/win32")
 endif()
 
 # includes
@@ -222,15 +225,8 @@ endif()
 
 # GMP things
 # => GMP_INCLUDE_DIR, GMP_LIBRARY
-
-set(GMP_SEARCH true)
-if(MSVC)
-    # expect vcpkg installed GMP
-    find_path(GMP_INCLUDE_DIR gmp.h)
-    find_library(GMP_LIBRARY NAMES gmp)
-else()
-
-endif()
+find_path(GMP_INCLUDE_DIR gmp.h)
+find_library(GMP_LIBRARY NAMES gmp)
 
 if(GMP_INCLUDE_DIR AND GMP_LIBRARY)
     set(GMP_FOUND TRUE)
@@ -242,6 +238,9 @@ else()
     message(SEND_ERROR "GMP not found..")
 endif()
 
+# Oniguruma
+find_path(ONIG_INCLUDE_DIR oniguruma.h)
+find_library(ONIG_LIBRARY NAMES onig)
 
 # GC things
 # => gc_srcs
@@ -305,62 +304,18 @@ else()
         )
 endif()
 
-# Onigruma things
-
-set(MOSH_ONIG_DIR extlibs/onig-5.9.2)
-set(onig_srcs
-    ${MOSH_ONIG_DIR}/regint.h
-    ${MOSH_ONIG_DIR}/regparse.h
-    ${MOSH_ONIG_DIR}/regenc.h
-    ${MOSH_ONIG_DIR}/st.h
-    ${MOSH_ONIG_DIR}/regerror.c
-    ${MOSH_ONIG_DIR}/regparse.c
-    ${MOSH_ONIG_DIR}/regext.c
-    ${MOSH_ONIG_DIR}/regcomp.c
-    ${MOSH_ONIG_DIR}/regexec.c
-    ${MOSH_ONIG_DIR}/reggnu.c
-    ${MOSH_ONIG_DIR}/regenc.c
-    ${MOSH_ONIG_DIR}/regsyntax.c
-    ${MOSH_ONIG_DIR}/regtrav.c
-    ${MOSH_ONIG_DIR}/regversion.c
-    ${MOSH_ONIG_DIR}/st.c
-    ${MOSH_ONIG_DIR}/regposix.c
-    ${MOSH_ONIG_DIR}/regposerr.c
-    ${MOSH_ONIG_DIR}/enc/unicode.c
-    ${MOSH_ONIG_DIR}/enc/ascii.c
-    ${MOSH_ONIG_DIR}/enc/utf8.c
-    ${MOSH_ONIG_DIR}/enc/utf16_be.c
-    ${MOSH_ONIG_DIR}/enc/utf16_le.c
-    ${MOSH_ONIG_DIR}/enc/utf32_be.c
-    ${MOSH_ONIG_DIR}/enc/utf32_le.c
-    ${MOSH_ONIG_DIR}/enc/euc_jp.c
-    ${MOSH_ONIG_DIR}/enc/sjis.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_1.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_2.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_3.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_4.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_5.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_6.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_7.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_8.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_9.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_10.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_11.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_13.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_14.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_15.c
-    ${MOSH_ONIG_DIR}/enc/iso8859_16.c
-    ${MOSH_ONIG_DIR}/enc/euc_tw.c
-    ${MOSH_ONIG_DIR}/enc/euc_kr.c
-    ${MOSH_ONIG_DIR}/enc/big5.c
-    ${MOSH_ONIG_DIR}/enc/gb18030.c
-    ${MOSH_ONIG_DIR}/enc/koi8_r.c
-    ${MOSH_ONIG_DIR}/enc/cp1251.c
-    )
-
 # mosh
 
-include_directories(${PROJECT_BINARY_DIR}/cmake extlibs/gc-cvs/include extlibs/gc-cvs/include/gc extlibs/gc-cvs/libatomic_ops/src src ${GMP_INCLUDE_DIR} ${MOSH_ONIG_DIR} ${ARCH_INCLUDE} gtest src/posix/terminal src/generic)
+include_directories(${PROJECT_BINARY_DIR}/cmake 
+    extlibs/gc-cvs/include 
+    extlibs/gc-cvs/include/gc 
+    src 
+    ${GMP_INCLUDE_DIR} 
+    ${ONIG_INCLUDE_DIR} 
+    ${ARCH_INCLUDE} 
+    gtest 
+    src/posix/terminal 
+    src/generic)
 
 if(CMAKE_COMPILER_IS_GNUCC)
     if(XCODE)
@@ -614,15 +569,13 @@ if(WIN32)
         PROPERTIES COMPILE_FLAGS "-D_UNICODE -DUNICODE -DWIN32_LEAN_AND_MEAN")
 endif()
 source_group(gc FILES ${gc_srcs})
-source_group(oniguruma FILES ${onig_srcs})
 add_executable(${MOSH_EXECUTABLE_NAME}
-    ${onig_srcs} 
     ${gc_srcs} 
     ${mosh_core_srcs} 
     ${mosh_core_hdrs}
     ${mosh_runtime_src}
     src/main.cpp)
-target_link_libraries(${MOSH_EXECUTABLE_NAME} ${GMP_LIBRARY} ${arch_libs})
+target_link_libraries(${MOSH_EXECUTABLE_NAME} ${GMP_LIBRARY} ${ONIG_LIBRARY} ${arch_libs})
 
 if(MOSH_PORTABLE)
     install(TARGETS ${MOSH_EXECUTABLE_NAME} DESTINATION .)
@@ -632,13 +585,12 @@ endif()
 
 if(MOSH_WITH_NMOSH_GUI)
     add_executable(${MOSH_GUI_EXECUTABLE_NAME} WIN32
-        ${onig_srcs} 
         ${gc_srcs} 
         ${mosh_core_srcs} 
         ${mosh_core_hdrs}
         ${mosh_runtime_src}
         src/win32/winmain.cpp)
-    target_link_libraries(${MOSH_GUI_EXECUTABLE_NAME} ${GMP_LIBRARY} ${arch_libs})
+    target_link_libraries(${MOSH_GUI_EXECUTABLE_NAME} ${GMP_LIBRARY} ${ONIG_LIBRARY} ${arch_libs})
 
     if(MOSH_PORTABLE)
         install(TARGETS ${MOSH_GUI_EXECUTABLE_NAME} DESTINATION .)
@@ -782,7 +734,7 @@ add_library(testinggc EXCLUDE_FROM_ALL
 add_library(testingmosh EXCLUDE_FROM_ALL
     ${mosh_core_srcs}
     ${PROJECT_SOURCE_DIR}/gtest/gtest/gtest-all.cc
-    ${mosh_runtime_src} ${onig_srcs} 
+    ${mosh_runtime_src}
     src/TestingSignalHandler.cpp
     src/TestingVM.cpp)
 
@@ -830,7 +782,7 @@ macro(add_moshcoretest testname)
             PROPERTIES COMPILE_FLAGS "${source_is_utf8} -D_UNICODE -DUNICODE -DWIN32_LEAN_AND_MEAN")
     endif()
     add_executable(moshtest${testname} ${gtest_srcs} src/${testname}.cpp)
-    target_link_libraries(moshtest${testname} testingmosh testinggc ${GMP_LIBRARY} ${arch_libs})
+    target_link_libraries(moshtest${testname} testingmosh testinggc ${GMP_LIBRARY} ${ONIG_LIBRARY} ${arch_libs})
     set_target_properties(moshtest${testname} PROPERTIES FOLDER Test)
     add_test(mosh-${testname} moshtest${testname})
 endmacro(add_moshcoretest)

--- a/Makefile.am
+++ b/Makefile.am
@@ -346,7 +346,7 @@ nobase_data_DATA = ${mosh_core_libraries} ${MOSH_PLUGINS} #${mosh_core_fasl_libr
 INCLUDES       = -I $(top_srcdir)/$(BOEHM_GC_DIR)/include -I $(top_srcdir)/$(BOEHM_GC_DIR)/include/gc -I $(top_srcdir)/$(BOEHM_GC_DIR)/libatomic_ops/src -I$(top_srcdir)/src
 EXTRA_DIST     = \
 boot/vm.scm boot/baselib boot/compiler.scm \
-boot/free-vars.scm misc/scripts boot/baselib/match.scm doc \
+boot/free-vars.scm misc/scripts misc/logo boot/baselib/match.scm doc \
 boot/free-vars-decl.scm \
 boot/runtimes/psyntax-mosh/psyntax.scm \
 boot/runtimes/psyntax-mosh/psyntax \
@@ -396,7 +396,7 @@ src/bsd/kqueue/Library.scm src/generic/Library.scm \
 src/win32/aio/Library.scm src/win32/gui/Library.scm src/win32/misc/Library.scm \
 src/win32/plugins/mm/Library.scm src/win32/plugins/mm/moshmm.c \
 src/win32/winmain.cpp \
-src/private/config.h
+src/private/config.h src/win 
 
 GENERATED = \
 src/all-tests.scm src/Scanner.cpp src/NumberScanner.cpp  \


### PR DESCRIPTION
Add Win64 AMD64 to CI. 

It uses prebuilt libraries which are downloaded from:
https://github.com/okuoku/nmosh-build-prerequisites/releases/tag/v0.1.1
to save 30min of build time and ease of maintaining. 

- Add `src/win` and `misc/logo` to additional `EXTRA_DIST` target
- Remove in-tree Oniguruma build support from CMake. Now it is only used on MonaOS target.
