### PR TITLE
Fix bignum 64bits I/O with LLP64 architecture

### DIFF
--- a/src/Bignum.h
+++ b/src/Bignum.h
@@ -38,18 +38,25 @@
 #ifdef _WIN32
     #ifdef _WIN64
         #define MOSH_BIGNUM_SIZEOF_INTPTR_T 8
+        #define MOSH_BIGNUM_SIZEOF_LONG 4
     #else
         #define MOSH_BIGNUM_SIZEOF_INTPTR_T 4
+        #define MOSH_BIGNUM_SIZEOF_LONG 4
     #endif
 #elif defined(__GNUC__)
     #if defined(__WORDSIZE) && (__WORDSIZE == 64) // Some FreeBSD have no __WORDSIZE.
         #define MOSH_BIGNUM_SIZEOF_INTPTR_T 8
+        #define MOSH_BIGNUM_SIZEOF_LONG 8
     #else
         #define MOSH_BIGNUM_SIZEOF_INTPTR_T 4
+        #define MOSH_BIGNUM_SIZEOF_LONG 4
     #endif
 #else
     #error "define MOSH_BIGNUM_SIZEOF_INTPTR_T"
 #endif
+
+static_assert(MOSH_BIGNUM_SIZEOF_INTPTR_T == sizeof(intptr_t), "Unmatched intptr_t size");
+static_assert(MOSH_BIGNUM_SIZEOF_LONG == sizeof(long), "Unmatched long size");
 
 namespace scheme {
 
@@ -191,7 +198,7 @@ public:
     uint64_t toU64() const
     {
         MOSH_ASSERT(fitsU64());
-#if (MOSH_BIGNUM_SIZEOF_INTPTR_T == 4)
+#if (MOSH_BIGNUM_SIZEOF_LONG == 4)
         uint64_t ret = 0;
         mpz_t temp;
         mpz_init(temp);
@@ -211,7 +218,7 @@ public:
     int64_t toS64() const
     {
         MOSH_ASSERT(fitsS64());
-#if (MOSH_BIGNUM_SIZEOF_INTPTR_T == 4)
+#if (MOSH_BIGNUM_SIZEOF_LONG == 4)
         uint64_t ret = 0;
         mpz_t temp;
         mpz_init(temp);

--- a/src/Bignum.h
+++ b/src/Bignum.h
@@ -44,7 +44,10 @@
         #define MOSH_BIGNUM_SIZEOF_LONG 4
     #endif
 #elif defined(__GNUC__)
-    #if defined(__WORDSIZE) && (__WORDSIZE == 64) // Some FreeBSD have no __WORDSIZE.
+    #if defined(__WORDSIZE) && (__WORDSIZE == 64)
+        #define MOSH_BIGNUM_SIZEOF_INTPTR_T 8
+        #define MOSH_BIGNUM_SIZEOF_LONG 8
+    #elif defined(__LP64__)
         #define MOSH_BIGNUM_SIZEOF_INTPTR_T 8
         #define MOSH_BIGNUM_SIZEOF_LONG 8
     #else

--- a/tests/misc.scm
+++ b/tests/misc.scm
@@ -163,5 +163,43 @@
     (test-equal #vu8(5 6) ans1)
     ))
 
+;; https://github.com/higepon/mosh/issues/111 Bignum on LLP64
+
+(let ((n 1000000000000)
+      (bv #f))
+  (set! bv (make-bytevector 8 95))
+  (bytevector-u64-set! bv 0 n (endianness little))
+  (test-equal n (bytevector-u64-ref bv 0 (endianness little)))
+  (set! bv (make-bytevector 8 96))
+  (bytevector-u64-set! bv 0 n (endianness big))
+  (test-equal n (bytevector-u64-ref bv 0 (endianness big)))
+  (set! bv (make-bytevector 8 97))
+  (bytevector-u64-native-set! bv 0 n)
+  (test-equal n (bytevector-u64-native-ref bv 0)))
+
+(let ((n 1000000000000)
+      (bv #f))
+  (set! bv (make-bytevector 8 95))
+  (bytevector-s64-set! bv 0 n (endianness little))
+  (test-equal n (bytevector-s64-ref bv 0 (endianness little)))
+  (set! bv (make-bytevector 8 96))
+  (bytevector-s64-set! bv 0 n (endianness big))
+  (test-equal n (bytevector-s64-ref bv 0 (endianness big)))
+  (set! bv (make-bytevector 8 97))
+  (bytevector-s64-native-set! bv 0 n)
+  (test-equal n (bytevector-s64-native-ref bv 0)))
+
+(let ((n -1000000000000)
+      (bv #f))
+  (set! bv (make-bytevector 8 95))
+  (bytevector-s64-set! bv 0 n (endianness little))
+  (test-equal n (bytevector-s64-ref bv 0 (endianness little)))
+  (set! bv (make-bytevector 8 96))
+  (bytevector-s64-set! bv 0 n (endianness big))
+  (test-equal n (bytevector-s64-ref bv 0 (endianness big)))
+  (set! bv (make-bytevector 8 97))
+  (bytevector-s64-native-set! bv 0 n)
+  (test-equal n (bytevector-s64-native-ref bv 0)))
+
 (test-results)
 


### PR DESCRIPTION
Fixes #111 

Fix bignum I/O against bytevector by fixing `toU64` and `toS64` functions. In addition, this patch addresses:

- Fix `MOSH_BIGNUM_SIZEOF_INTPTR_T` detection on non-glibc platforms: Use `__LP64__` to detect 64bits platforms. This is defined on amd64 and arm64.
- Add `static_assert` to detect misconfiguration
- Add tests in `misc.scm` to detect misconfiguration