### PR TITLE
Reader: `std::isalpha` is in `<cctype>`

### DIFF
--- a/src/Reader.cpp
+++ b/src/Reader.cpp
@@ -29,7 +29,7 @@
  *  $Id: reader.cpp 183 2008-07-04 06:19:28Z higepon $
  */
 
-#include <ctype.h>
+#include <cctype>
 #include <algorithm>
 #include "Object.h"
 #include "Object-inl.h"


### PR DESCRIPTION
Trivial. Commit https://github.com/higepon/mosh/commit/f622f0870943d3f5544873b1329ac1ae1522e33e added reference to `std::isalpha` but it needs  including `<cctype>` to populate `std::isalpha` declaration.

This patch fixes compilation on old VisualStudio (2017).