### PR TITLE
test: Disable concurrent tests on BSDs/Cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -449,11 +449,18 @@ check: test
 MOSHBIN ="MOSH_LOADPATH=$(abs_top_srcdir)/lib $(abs_builddir)/mosh $(MOSH_TESTARGS)"
 NMOSHBIN ="NMOSH_CACHEDIR=$(abs_builddir)/nmosh-cache MOSH_LOADPATH=$(abs_top_srcdir)/lib $(abs_builddir)/nmosh $(MOSH_TESTARGS)"
 
+run_concurrent_tests=
+run_concurrent_ntests=
+if RUN_CONCURRENT_TESTS
+run_concurrent_tests+=testT
+run_concurrent_ntests+=ntestT
+endif
+
 
 test: ptest ntest
 Xtest: ptest ntest testD ntestD
-ptest: testB testR testL
-ntest: ntestB ntestR ntestL
+ptest: testB testR testL $(run_concurrent_tests)
+ntest: ntestB ntestR ntestL $(run_concurrent_tests)
 
 testB: ./mosh src/all-tests.scm # lib/libffitest.so.1.0 
 	(MOSH_TARGET=$(MOSHBIN) $(MAKE) -C $(top_srcdir) -f tests/Makefile runtest)
@@ -467,6 +474,9 @@ testL:
 
 testR:
 	(MOSH_TARGET=$(MOSHBIN) $(MAKE) -C $(top_srcdir)/tests/r6rs-test-suite)
+
+testT:
+	(MOSH_TARGET=$(MOSHBIN) $(MAKE) -C $(top_srcdir) -f tests/Makefile runtest-concurrent)
 
 #check-am is Automake's internal target..
 #testU: check-am
@@ -483,6 +493,9 @@ ntestL:
 
 ntestR:
 	(MOSH_TARGET=$(NMOSHBIN) $(MAKE) -C $(top_srcdir)/tests/r6rs-test-suite)
+
+ntestT:
+	(MOSH_TARGET=$(NMOSHBIN) $(MAKE) -C $(top_srcdir) -f tests/Makefile runtest-concurrent)
 
 testD:
 	(MOSH_TARGET=$(MOSHBIN) $(MAKE) -C $(top_srcdir) -f tests/Makefile runtest-for-developer)

--- a/configure.ac
+++ b/configure.ac
@@ -237,17 +237,20 @@ MOSH_INTEL_OPTS="$MOSH_GENERIC_OPTS -momit-leaf-frame-pointer -fomit-frame-point
 has_gc_pthread=false
 has_gc_darwin=false
 has_gc_win32=false
+run_concurrent_tests=false
 AC_MSG_CHECKING([check threads])
 case "$target_os" in
 *darwin*)
   AC_DEFINE(GC_DARWIN_THREADS,1,[Define to use Darwin threads])
   has_gc_pthread=true
   has_gc_darwin=true
+  run_concurrent_tests=true
   ;;
 *linux*)
   AC_DEFINE(GC_LINUX_THREADS,1,[Define to use Linux threads])
   AC_DEFINE(_REENTRANT,1,[Define to use reentrant libc])
   has_gc_pthread=true
+  run_concurrent_tests=true
   ;;
 freebsd*)
   AC_DEFINE(GC_FREEBSD_THREADS,1,[Define to use FreeBSD threads])
@@ -281,6 +284,7 @@ esac
 AM_CONDITIONAL(GC_PTHREAD, $has_gc_pthread)
 AM_CONDITIONAL(GC_DARWIN, $has_gc_darwin)
 AM_CONDITIONAL(GC_WIN32, $has_gc_win32)
+AM_CONDITIONAL(RUN_CONCURRENT_TESTS, $run_concurrent_tests)
 # Checks for cpu
 AC_MSG_CHECKING([for supported architecture])
 MOSH_LDADD_ARCH="-ldl -lpthread"

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -36,8 +36,6 @@ runtest:
 	$(MOSH_TARGET) tests/lists.scm
 	$(MOSH_TARGET) tests/match.scm
 	$(MOSH_TARGET) tests/srfi-39.scm
-#	$(MOSH_TARGET) tests/concurrent.scm
-	$(MOSH_TARGET) tests/concurrent-crash.scm
 	$(MOSH_TARGET) tests/number.scm
 	$(MOSH_TARGET) tests/cgi.scm
 	$(MOSH_TARGET) tests/shorten.scm
@@ -53,6 +51,10 @@ runtest:
 	# This grep pattern should work with both mosh and nmosh.
 	$(MOSH_TARGET) tests/invalid-syntax.scm 2>&1 >/dev/null | grep 'invalid-syntax.scm' -A10 -B10
 	$(MOSH_TARGET) tests/wrong_argument.scm 2>&1 | grep 'wrong_argument.scm'
+
+runtest-concurrent:
+#	$(MOSH_TARGET) tests/concurrent.scm
+	$(MOSH_TARGET) tests/concurrent-crash.scm
 
 runtest-ffi:
 	(cd $(MOSH_BUILDDIR) && $(MOSH_TARGET) $(MOSH_SRCDIR)/tests/ffi.scm)


### PR DESCRIPTION
Fixes #94 

Disable concurrent tests on BSDs/Cygwin since it's unstable on there. `make testT` still runs tests manually on these platforms.

Disabled test(`concurrent-crash.scm`) still enabled on macOS and Linux.