### PR TITLE
build: Correct Scheme libraries installation paths

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@ GLOBAL_CFLAGS =  $(ONIG_CFLAGS) $(GMP_CFLAGS) \
 		 -Wall \
 		 -I src -I $(includedir) \
 		 -D MONA_SCHEME -D USE_BOEHM_GC \
-		 -D MOSH_LIB_PATH="\"$(MOSH_LIB_PATH)\"" \
+		 -D MOSH_LIB_PATH="\"${datadir}/$(INSTALLNAME)-$(PACKAGE_VERSION)\"" \
 		 -D_FILE_OFFSET_BITS=64 -Wall -pipe $(DEBUG_FLAGS) \
 		 $(GC_CFLAGS) \
 		 $(MOSH_OPTS) # temp -Wno-deprecated
@@ -338,10 +338,9 @@ $(top_builddir)/plugins/mosh_curses.mplg: $(top_srcdir)/src/ext/curses/mosh_curs
 endif
 
 #mosh_core_fasl_libraries = $(mosh_core_libraries:.ss=.ss.fasl)
-
-datadir = $(MOSH_LIB_PATH)
-data_DATA = src/all-tests.scm
-nobase_data_DATA = ${mosh_core_libraries} ${MOSH_PLUGINS} #${mosh_core_fasl_libraries}
+scmlibdir = ${datadir}/$(INSTALLNAME)-$(PACKAGE_VERSION)
+scmlib_DATA = src/all-tests.scm
+nobase_scmlib_DATA = ${mosh_core_libraries} ${MOSH_PLUGINS} #${mosh_core_fasl_libraries}
 
 INCLUDES       = -I $(top_srcdir)/$(BOEHM_GC_DIR)/include -I $(top_srcdir)/$(BOEHM_GC_DIR)/include/gc -I $(top_srcdir)/$(BOEHM_GC_DIR)/libatomic_ops/src -I$(top_srcdir)/src
 EXTRA_DIST     = \
@@ -591,10 +590,6 @@ dist-hook:
 	-rm -f $(top_distdir)/lib/mosh/mysql.ss
 	-rm -f $(top_distdir)/lib/libffitest.so.1.0
 	-rm -f $(top_distdir)/src/config.h
-
-install-data-hook:
-	@echo Setting up plugins permission bit..
-	-@chmod +x $(DESTDIR)$(MOSH_LIB_PATH)/plugins/*
 
 # for FFI test
 lib/libffitest.so.1.0: src/ffitest.c

--- a/Makefile.am
+++ b/Makefile.am
@@ -340,7 +340,7 @@ endif
 #mosh_core_fasl_libraries = $(mosh_core_libraries:.ss=.ss.fasl)
 scmlibdir = ${datadir}/$(INSTALLNAME)-$(PACKAGE_VERSION)
 scmlib_DATA = src/all-tests.scm
-nobase_scmlib_DATA = ${mosh_core_libraries} ${MOSH_PLUGINS} #${mosh_core_fasl_libraries}
+nobase_scmlib_DATA = ${mosh_core_libraries} lib/mosh/config.ss ${MOSH_PLUGINS} #${mosh_core_fasl_libraries}
 
 INCLUDES       = -I $(top_srcdir)/$(BOEHM_GC_DIR)/include -I $(top_srcdir)/$(BOEHM_GC_DIR)/include/gc -I $(top_srcdir)/$(BOEHM_GC_DIR)/libatomic_ops/src -I$(top_srcdir)/src
 EXTRA_DIST     = \

--- a/configure.ac
+++ b/configure.ac
@@ -34,7 +34,6 @@ else
     rm -f $sedscript0 $sedscript1
 fi
 AC_SUBST(INSTALLNAME)
-AC_SUBST(MOSH_LIB_PATH, "${datadir}/$INSTALLNAME-$PACKAGE_VERSION")
 
 # Checks for programs.
 dnl AC_PROG_LIBTOOL # use LTLIBRARIES

--- a/misc/scripts/gen-corelibmk.sps
+++ b/misc/scripts/gen-corelibmk.sps
@@ -25,5 +25,10 @@
         (display "\n\n" p))))
 
 (output (filter (^e (let ((p (path-extension e)))
-                      (and p (library? p)))) (listup "lib")))
+                      (and p (library? p)
+                           ;; Exclude lib/mosh/config.ss because it is 
+                           ;; generated on configuration time and it is 
+                           ;; explicitly listed in Makefile.am
+                           (not (string=? e "lib/mosh/config.ss"))))) 
+                (listup "lib")))
 


### PR DESCRIPTION
Fixes #131
Fixes #133 

Previously, libraries are installed under `/usr/local/share` directly. Move this to `/usr/local/share/mosh-<VERSION>/`.

- Move variable reference to `Makefile.am` as [the manual suggests](https://github.com/higepon/mosh/issues/131#issuecomment-1256427147)
- Remove `install-data-hook` which is not required; NMosh plugins are compiled as shared library and will get executable permission anyway
- Rename `datadir` => `scmlibdir` in `Makefile.am` just same as `MOSH_LIB_PATH`; it seems overriding `datadir` not working as expected.
- Rename `scmlib_DATA` `nobase_scmlib_DATA`

EDIT: Added #133 fix as well:

- Modify `misc/scripts/gen-corelibmk.sps` to exclude `(mosh config)`
- Explicitly require `(mosh config)` installation in `Makefile.am`