### PR TITLE
Support R7RS library with include

### DIFF
--- a/boot/runtimes/psyntax-mosh/psyntax/compat.ss
+++ b/boot/runtimes/psyntax-mosh/psyntax/compat.ss
@@ -240,7 +240,7 @@
     (let ([sexp (with-input-from-file file-name read-annotated)])
       ;; We rewrite R7RS library to R6RS library here.
       (if (and r7rs-enabled? (pair? sexp) (eq? (car sexp) 'define-library))
-          (rewrite-define-library "" sexp)
+          (rewrite-define-library (path-dirname file-name) sexp)
           sexp)))
 
   (define make-parameter

--- a/boot/runtimes/psyntax-mosh/psyntax/library-manager.ss
+++ b/boot/runtimes/psyntax-mosh/psyntax/library-manager.ss
@@ -131,7 +131,7 @@
 
   (define library-extensions
     (make-parameter
-      '(".mosh.sls" ".sls" ".ss" ".scm")
+      '(".sld" ".sls" ".ss" ".scm")
       (lambda (x)
         (if (and (list? x) (for-all string? x))
             (map (lambda (x) x) x)

--- a/tests/r7rs/library-converter/r7rs/include-test/foo.scm
+++ b/tests/r7rs/library-converter/r7rs/include-test/foo.scm
@@ -1,0 +1,1 @@
+(define foo-var "foo!")

--- a/tests/r7rs/library-converter/r7rs/include-test/foo.sld
+++ b/tests/r7rs/library-converter/r7rs/include-test/foo.sld
@@ -1,0 +1,5 @@
+
+(define-library (include-test foo)
+    (export foo-var)
+    (import (scheme base))
+    (include "foo.scm"))

--- a/tests/r7rs/library-converter/run-include-test.scm
+++ b/tests/r7rs/library-converter/run-include-test.scm
@@ -1,0 +1,5 @@
+(import (include-test foo)
+        (mosh test))
+
+(test-equal "foo!" foo-var)
+(test-results)

--- a/tests/r7rs/library-converter/test.scm
+++ b/tests/r7rs/library-converter/test.scm
@@ -6,12 +6,12 @@
 (test-equal '(make rows (rename (put! set!))) (rewrite-export '(make rows (rename put! set!))))
 
 ;; body with include.
-(test-equal '((include "/foo/bar.scm")) (rewrite-body "/foo" '((include "bar.scm"))))
+(test-equal '((include "/foo/bar.scm")) (rewrite-body "/foo/" '((include "bar.scm"))))
 
 ;; body with two include.
-(test-equal '((include "/foo/bar.scm") (include "/foo/baz.scm")) (rewrite-body "/foo" '((include "bar.scm") (include "baz.scm"))))
+(test-equal '((include "/foo/bar.scm") (include "/foo/baz.scm")) (rewrite-body "/foo/" '((include "bar.scm") (include "baz.scm"))))
 
-(test-equal '((include "/foo/bar.scm") (include "/foo/baz.scm")) (rewrite-body "/foo" '((include "bar.scm" "baz.scm"))))
+(test-equal '((include "/foo/bar.scm") (include "/foo/baz.scm")) (rewrite-body "/foo/" '((include "bar.scm" "baz.scm"))))
 
 ;; define-library
 (test-values (values '(my lib) '(make rows (rename put! set!)) '((scheme base)) '((begin 3)))
@@ -32,5 +32,9 @@
     (parse-define-library '(define-library (my lib)
                                            (export make rows (rename put! set!))
                                            (import (scheme base)))))
+
+(test-equal "/foo/bar/baz/" (path-dirname "/foo/bar/baz/hige.scm"))
+(test-equal "" (path-dirname "hige.scm"))
+
 
 (test-results)


### PR DESCRIPTION
With this change mosh is able to load very simple R7RS library with include as follows.

foo.sld
```
(define-library (include-test foo)
    (export foo-var)
    (import (scheme base))
    (include "foo.scm"))
```

There are still many unsupported cases I'll separately fix them one by one. 
Note I didn't test this in Windows. Hope it passes the CI.