### PR TITLE
Dragonfly BSD support and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -384,6 +384,34 @@ jobs:
             ./configure
             gmake -j4
 
+  build-dist-dfly:
+    name: "DragonFly VM"
+    needs: build-linux
+    runs-on: macos-12
+    timeout-minutes: 40
+    steps:
+      - name: "Download artifact"
+        uses: actions/download-artifact@v3
+        with:
+          name: source-ubuntu-latest
+      - name: "Extract artifact"
+        run: |
+          tar xzv -f ${{ env.mosh_latest }}.tar.gz
+          rm ${{ env.mosh_latest }}.tar.gz
+      - name: "Build with VM"
+        uses: vmactions/dragonflybsd-vm@v0.0.5
+        with:
+          usesh: true
+          copyback: false
+          mem: 2048
+          prepare: |
+            pkg install -y gmake oniguruma pkgconf gmp
+          run: |
+            cd ${{ env.mosh_latest }}
+            ./configure
+            gmake -j4
+            gmake check
+
   build-dist-win64:
     name: "Win64 AMD64 (NMosh)"
     needs: build-linux

--- a/configure.ac
+++ b/configure.ac
@@ -255,6 +255,10 @@ freebsd*)
   AC_DEFINE(GC_FREEBSD_THREADS,1,[Define to use FreeBSD threads])
   has_gc_pthread=true
   ;;
+dragonfly*)
+  AC_DEFINE(GC_FREEBSD_THREADS,1,[Define to use FreeBSD threads])
+  has_gc_pthread=true
+  ;;
 netbsd*)
   AC_DEFINE(GC_NETBSD_THREADS,1,[Define to use NetBSD threads])
   has_gc_pthread=true
@@ -370,6 +374,11 @@ i[[3456]]86|pentium)
                 ;;
                 *openbsd*)
                 AC_MSG_RESULT([x86_64(OpenBSD amd64)])
+                MOSH_OPTS="$MOSH_INTEL_OPTS"
+                MOSH_LDADD_ARCH="-lpthread"
+                ;;
+                *dragonfly*)
+                AC_MSG_RESULT([x86_64(DragonflyBSD amd64)])
                 MOSH_OPTS="$MOSH_INTEL_OPTS"
                 MOSH_LDADD_ARCH="-lpthread"
                 ;;

--- a/gtest/gtest/gtest.h
+++ b/gtest/gtest/gtest.h
@@ -324,11 +324,13 @@
 #define GTEST_OS_FREEBSD 1
 #elif defined(__OpenBSD__)
 #define GTEST_OS_OPENBSD 1
+#elif defined(__DragonFly__)
+#define GTEST_OS_DRAGONFLY 1
 #endif  // __CYGWIN__
 
 #if GTEST_OS_CYGWIN || GTEST_OS_LINUX || GTEST_OS_MAC || GTEST_OS_SYMBIAN || \
     GTEST_OS_SOLARIS || GTEST_OS_AIX || GTEST_OS_NETBSD || \
-    GTEST_OS_FREEBSD || GTEST_OS_OPENBSD
+    GTEST_OS_FREEBSD || GTEST_OS_OPENBSD || GTEST_OS_DRAGONFLY
 
 // On some platforms, <regex.h> needs someone to define size_t, and
 // won't compile otherwise.  We can #include it here as we already

--- a/src/OSCompat.cpp
+++ b/src/OSCompat.cpp
@@ -33,7 +33,7 @@
 #ifndef MONA
 #ifdef __APPLE__
 #define _DARWIN_C_SOURCE 1
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 /* default visibility for sysctl */
 #elif defined(__NetBSD__)
 #define _NETBSD_SOURCE 1
@@ -61,10 +61,10 @@
 #ifdef MONA
 #include <monapi.h>
 #endif
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__DragonFly__)
 #include <dlfcn.h>
 #include <sys/sysctl.h>
-#endif /* __FreeBSD__ */
+#endif /* __FreeBSD__ || __DragonFly__ */
 #include "scheme.h"
 #include "Object.h"
 #include "Object-inl.h"
@@ -968,7 +968,7 @@ ucs4string scheme::getMoshExecutablePath(bool& isErrorOccured)
     }
     isErrorOccured = true;
     return ucs4string(UC(""));
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
     char path[PATH_MAX];
     size_t len = PATH_MAX;
     // read kern.proc.pathname.-1

--- a/src/OSCompatSocket.cpp
+++ b/src/OSCompatSocket.cpp
@@ -35,7 +35,7 @@
 #define _NETBSD_SOURCE 1
 #elif defined(__OpenBSD__)
 #define _BSD_SOURCE 1
-#elif !defined(_WIN32) && !defined(MONA)
+#elif !defined(_WIN32) && !defined(MONA) && !defined(__DragonFly__)
 #define _POSIX_C_SOURCE 200809L // for addrinfo (POSIX 2001)
 #endif
 

--- a/src/UtilityProcedures.cpp
+++ b/src/UtilityProcedures.cpp
@@ -33,7 +33,7 @@
 #include <monapi.h>
 #elif defined(__APPLE__)
 #define _DARWIN_C_SOURCE 1 // for struct timezone
-#elif defined(__FreeBSD__)
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
 #define _XOPEN_SOURCE 700 // for gettimeofday
 #elif defined(__NetBSD__)
 #define _NETBSD_SOURCE 1 // for C++ headers work


### PR DESCRIPTION
Fix build on DragonFly BSD and add it to CI.

DragonFly BSD https://www.dragonflybsd.org/ is a fork of FreeBSD4. Which is heavily diverged from FreeBSD in kernel implementation but fortunately it keeps mostly same in userland APIs for us. Thus, I have borrowed OS specific from FreeBSD.